### PR TITLE
Sproutcore samples on old repo

### DIFF
--- a/content/demos.html
+++ b/content/demos.html
@@ -1,8 +1,8 @@
 <h1>Demos</h1>
 <p>You can try out a recent build of <a href="http://demo.sproutcore.com/">all of the SproutCore demos.</a></p>
-<p>The source code for the demos is <a href="http://github.com/sproutit/sproutcore-samples">available on GitHub</a>. To get them running on your machine, first <a href="/get-started/">install SproutCore</a>, then:</p>
+<p>The source code for the demos is <a href="http://github.com/sproutcore/sproutcore-samples">available on GitHub</a>. To get them running on your machine, first <a href="/get-started/">install SproutCore</a>, then:</p>
 <ol class="block">
-  <li>$ git clone git://github.com/sproutit/sproutcore-samples.git
+  <li>$ git clone git://github.com/sproutcore/sproutcore-samples.git
 <code class="output">Initialized empty Git repository in /Users/tomdale/work/test/sproutcore-samples/.git/
 remote: Counting objects: 2644, done.
 remote: Compressing objects: 100% (1381/1381), done.


### PR DESCRIPTION
sprout-core samples are on github.com/sproutit/ while the project is now on github.com/sproutcore/ - once samples have been forked, this pull-req can be applied
